### PR TITLE
Remove BlockChange from packed structs

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -172,14 +172,14 @@ extern uint8_t motd_len;
 
 extern uint16_t client_count;
 
-#pragma pack(push, 1)
-
 typedef struct {
   short x;
   short z;
   uint8_t y;
   uint8_t block;
 } BlockChange;
+
+#pragma pack(push, 1)
 
 typedef struct {
   uint8_t uuid[16];


### PR DESCRIPTION
`#pragma pack (push, 1)` forces alignment to 1-byte.
While reordering the fields does help with memory accesses, it only works if the compiler can ensure 2-byte alignments for this struct.

Moving the `#pragma pack` away lets the compiler generate `lh` (load half) instructions instead of 2 `lb` (load byte) + shift + bitwise OR (see `getBlockChange()` example below).

Before:
<img width="490" height="252" alt="image" src="https://github.com/user-attachments/assets/0acb43dd-25aa-4820-a4c3-005e465c2ba8" />

After:
<img width="435" height="166" alt="image" src="https://github.com/user-attachments/assets/1a5bc4e3-0da7-48ef-a548-b57dff6b944c" />
