### PR TITLE
Correct windows build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For microcontrollers, see the section on **compilation** below.
 Before compiling, you'll need to dump registry data from a vanilla Minecraft server. On Linux, this can be done automatically using the `extract_registries.sh` script. Otherwise, the manual process is as follows: create a folder called `notchian` here, and put a Minecraft server JAR in it. Then, follow [this guide](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Data_Generators) to dump all of the registries. Finally, run `build_registries.js` with `node`, `bun`, or `deno`.
 
 - To target Linux, install `gcc` and run `./build.sh`
-- To target Windows, install [MSYS2](https://www.msys2.org/) (follow _all_ instructions on that page), and open the "MSYS2 MINGW64" shell once installed. From there, navigate to this project's directory and run `./build.sh`. Alternatively, install WSL and use `gcc`. Otherwise, there's no platform-native solution for Windows currently.
+- To target Windows, install [MSYS2](https://www.msys2.org/), and open the "MSYS2 MSYS" shell once installed. From there, install `gcc` (run `pacman -Sy gcc`), navigate to this project's directory and run `./build.sh`. Alternatively, install WSL and use `gcc`. Otherwise, there's no platform-native solution for Windows currently.
 - To target an ESP variant, set up a PlatformIO project (select the ESP-IDF framework, **not Arduino**) and clone this repository on top of it. See **Configuration** below for further steps. For better performance, consider changing the clock speed and enabling compiler optimizations. If you don't know how to do this, there are plenty of resources online.
 
 ## Configuration


### PR DESCRIPTION
MINGW64 isn't actually a full posix environment and lacks some of the headers required for building, MSYS (being a fork of cygwin) implements them making it possible to build without any modifications to the code
<img width="1455" height="416" alt="{7AB84301-850C-405D-B9CC-64D6B133180D}" src="https://github.com/user-attachments/assets/6674bbf1-e7c4-448e-9718-93d841cb6916" />
