### PR TITLE
Created dockerfile for the project.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# ---- Build stage ----
+FROM openjdk:21-jdk-slim AS builder
+
+RUN apt-get update && apt-get install -y \
+    build-essential gcc git curl nodejs npm unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone https://github.com/p2r3/bareiron.git .
+
+# Copy in Minecraft server.jar (must match version!)
+# COPY server.jar notchian/server.jar
+COPY notchian/ notchian/
+
+# Run registry extraction
+RUN chmod +x extract_registries.sh && ./extract_registries.sh
+
+# Build
+RUN gcc src/*.c -O3 -Iinclude -o bareiron
+
+# ---- Runtime stage ----
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY --from=builder /src/bareiron ./bareiron
+VOLUME ["/app/world"]
+EXPOSE 25565
+CMD ["./bareiron"]


### PR DESCRIPTION
# Bareiron Minecraft Server with Docker
This guide explains how to build and run the Bareiron minimalist Minecraft server inside a Docker container, including persistent world storage.

---

## 1. Build the Docker Image
To compile the server and create a Docker image named bareiron, use the following command:

> You will need to download the server.jar and place it into the notchian folder **first**

```
Bash

docker build -t bareiron .
```

---

## 2. Prepare Persistent Storage
Create a folder on your host machine to store your world data. This ensures your Minecraft world persists even if the container is removed.

```
Bash

mkdir -p ~/bareiron_world
```

---

## 3a. Run the Server Container
Run the Bareiron server in a detached Docker container with the following command:

```
Bash

docker run -d \
  --name mcserver \
  -p 25565:25565 \
  -v ~/bareiron_world:/app/world \
  bareiron
```
Explanation:

-d: Runs the container in detached mode (in the background).

--name mcserver: Assigns a friendly name to the container.

-p 25565:25565: Exposes the default Minecraft port to allow clients to connect.

-v ~/bareiron_world:/app/world: Mounts a host folder to the container for persistent world data.

bareiron: The name of the Docker image to run.

---

## 3b. Optional: Use a Named Docker Volume
As an alternative to a host folder, you can use a Docker-managed named volume for persistent storage.

```
Bash

docker run -d \
  --name mcserver \
  -p 25565:25565 \
  -v mc_world_data:/app/world \
  bareiron
```
Here, mc_world_data is the Docker volume that will store your world. You can inspect your volumes with these commands:

```
Bash

docker volume ls
docker volume inspect mc_world_data
```

---

## 4. Connect to the Server
Use a vanilla Minecraft client (version 1.21.8) and connect to the server using one of these addresses:

Same machine:

localhost:25565
Other devices on the LAN:

<host_machine_IP>:25565

---

## 5. Notes and Tips
The ~/bareiron_world folder (or named volume) will persist the world.bin file even if the container is removed.

Bareiron is minimalist; some vanilla features (e.g., fluids, chests) may be missing.

Only vanilla Minecraft clients are supported; mods such as Fabric or Forge may not work.

If you update server.jar, you must rebuild the Docker image: docker build -t bareiron .

To monitor the server's activity, check its logs: docker logs -f mcserver

---

## 6. Stopping and Removing the Server
To stop the server, use:

```
Bash

docker stop mcserver
```
To remove the container, use:

```
Bash

docker rm mcserver
```
(Your world data will persist in the volume or host folder.)