### PR TITLE
Add node: prefixes to build_registries script

### DIFF
--- a/build_registries.js
+++ b/build_registries.js
@@ -1,5 +1,5 @@
-const fs = require("fs/promises");
-const path = require("path");
+const fs = require("node:fs/promises");
+const path = require("node:path");
 
 // Overrides for block-to-item conversion
 const blockToItemOverrides = {


### PR DESCRIPTION
Pretty small and useless change, but the Node API docs do it, and it helps distinguish from NPM packages of the same name

For example [this, which claims to be an exact copy](https://www.npmjs.com/package/path) and [this, which claims to be held by Node](https://www.npmjs.com/package/fs))