### PR TITLE
Add support for Windows 98/32bit Windows cross compiling when running on the mingw64 shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Before compiling, you'll need to dump registry data from a vanilla Minecraft ser
 
 - To compile on Linux, install `gcc` and run `./build.sh`.
 - For compiling on Windows, there are a few options:
-  - To compile a native Windows binary: install [MSYS2](https://www.msys2.org/) and open the "MSYS2 MINGW64" shell. From there, run `pacman -Sy mingw-w64-x86_64-gcc`, navigate to this project's directory, and run `./build.sh`. 
-  - To compile a MSYS2-linked binary: install [MSYS2](https://www.msys2.org/), and open the "MSYS2 MSYS" shell. From there, install `gcc` (run `pacman -Sy gcc`), navigate to this project's directory and run `./build.sh`.
+  - To compile a native Windows binary: install [MSYS2](https://www.msys2.org/) and open the "MSYS2 MINGW64" shell. From there, run `pacman -Sy mingw-w64-x86_64-gcc`, navigate to this project's directory, and run `./build.sh`.
+  - To compile a native 32-bit binary (compatible with Windows 95/98, but why would you ever want that), use the same steps above, except with `pacman -Sy mingw-w64-cross-gcc` and `./build.sh --9x`.
+  - To compile a MSYS2-linked binary: install [MSYS2](https://www.msys2.org/), and open the "MSYS2 MSYS" shell. From there, install `gcc` (run `pacman -Sy gcc`), navigate to this project's directory and run `./build.sh`. 
   - To compile and run a Linux binary from Windows: install WSL, and from there install `gcc` and run `./build.sh` in this project's directory.
 - To target an ESP variant, set up a PlatformIO project (select the ESP-IDF framework, **not Arduino**) and clone this repository on top of it. See **Configuration** below for further steps. For better performance, consider changing the clock speed and enabling compiler optimizations. If you don't know how to do this, there are plenty of resources online.
 

--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,19 @@ case "$unameOut" in
     ;;
 esac
 
+# Default compiler
+compiler="gcc"
+
+# Handle arguments for windows 9x build
+for arg in "$@"; do
+  case $arg in
+    --9x)
+      compiler="/opt/bin/i686-w64-mingw32-gcc"
+      windows_linker="$windows_linker -Wl,--subsystem,console:4"
+      ;;
+  esac
+done
+
 rm -f "bareiron$exe"
-gcc src/*.c -O3 -Iinclude -o "bareiron$exe" $windows_linker
+$compiler src/*.c -O3 -Iinclude -o "bareiron$exe" $windows_linker
 "./bareiron$exe"

--- a/build.sh
+++ b/build.sh
@@ -29,8 +29,13 @@ compiler="gcc"
 for arg in "$@"; do
   case $arg in
     --9x)
-      compiler="/opt/bin/i686-w64-mingw32-gcc"
-      windows_linker="$windows_linker -Wl,--subsystem,console:4"
+      if [[ "$unameOut" == MINGW64_NT* ]]; then
+        compiler="/opt/bin/i686-w64-mingw32-gcc"
+        windows_linker="$windows_linker -Wl,--subsystem,console:4"
+      else
+        echo "Error: Building for Windows 9x is only supported when running under MinGW64."
+        exit 1
+      fi
       ;;
   esac
 done

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ for arg in "$@"; do
         compiler="/opt/bin/i686-w64-mingw32-gcc"
         windows_linker="$windows_linker -Wl,--subsystem,console:4"
       else
-        echo "Error: Building for Windows 9x is only supported when running under MinGW64."
+        echo "Error: Compiling for Windows 9x is only supported when running under the MinGW64 shell."
         exit 1
       fi
       ;;


### PR DESCRIPTION
Added an argument to the build script to allow cross compiling an executable that is compatible with windows 98 and newer versions by changing the subsystem version to 4.0 and using the 32bit gcc cross compiler. It also checks if the script is being run on the mingw64 shell.

To build the executable, run the build.sh script with the --9x argument:
./build.sh --9x

This assumes the user has installed [mingw-w64-cross-gcc](https://packages.msys2.org/base/mingw-w64-cross-gcc)
It also requires a CPU with at least SSE support aka a Pentium 3/Athlon or newer