### PR TITLE
fix printf size arguments

### DIFF
--- a/src/serialize.c
+++ b/src/serialize.c
@@ -44,7 +44,7 @@ int initSerializer () {
     // Read block changes from the start of the file directly into memory
     size_t read = fread(block_changes, 1, sizeof(block_changes), file);
     if (read != sizeof(block_changes)) {
-      printf("Read %u bytes from \"world.bin\", expected %u (block changes). Aborting.\n", read, sizeof(block_changes));
+      printf("Read %zu bytes from \"world.bin\", expected %zu (block changes). Aborting.\n", read, sizeof(block_changes));
       fclose(file);
       return 1;
     }
@@ -64,7 +64,7 @@ int initSerializer () {
     read = fread(player_data, 1, sizeof(player_data), file);
     fclose(file);
     if (read != sizeof(player_data)) {
-      printf("Read %u bytes from \"world.bin\", expected %u (player data). Aborting.\n", read, sizeof(player_data));
+      printf("Read %zu bytes from \"world.bin\", expected %zu (player data). Aborting.\n", read, sizeof(player_data));
       return 1;
     }
 


### PR DESCRIPTION
the z size argument for printf specifies size_t sized numbers, this would previously produce warnings on some compilers and also might print the wrong value on 64 bit systems.