### PR TITLE
Enable `-march=native` for optimized builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,5 +41,5 @@ for arg in "$@"; do
 done
 
 rm -f "bareiron$exe"
-$compiler src/*.c -O3 -Iinclude -o "bareiron$exe" $windows_linker
+$compiler src/*.c -O3 -march=native -Iinclude -o "bareiron$exe" $windows_linker
 "./bareiron$exe"


### PR DESCRIPTION
This change adds the `-march=native` compiler flag to enable architecture-specific optimizations, allows the compiler to generate instructions tuned for the host CPU, improving runtime performance on the build machine.