### PR TITLE
feat: add flowers to plains biome

### DIFF
--- a/build_registries.js
+++ b/build_registries.js
@@ -60,7 +60,9 @@ const blockWhitelist = [
   "composter",
   "coal_block",
   "copper_ore",
-  "copper_block"
+  "copper_block",
+  "poppy",
+  "dandelion"
 ];
 
 // Currently, only 4 biome types are supported, excluding "beach"
@@ -376,7 +378,9 @@ async function convert () {
         itemsAndBlocks.blockRegistry["diamond_block"],
         itemsAndBlocks.blockRegistry["redstone_block"],
         itemsAndBlocks.blockRegistry["coal_block"],
-        itemsAndBlocks.blockRegistry["copper_block"]
+        itemsAndBlocks.blockRegistry["copper_block"],
+        itemsAndBlocks.blockRegistry["poppy"],
+        itemsAndBlocks.blockRegistry["dandelion"]
       ],
       "mineable/axe": [
         itemsAndBlocks.blockRegistry["oak_log"],

--- a/include/globals.h
+++ b/include/globals.h
@@ -58,6 +58,9 @@
 // Cave generation Y level
 #define CAVE_BASE_DEPTH 24
 
+// Chance (in percent) of spawning a flower in plains biome per block
+#define FLOWER_SPAWN_CHANCE 2
+
 // Size of every major biome in multiples of CHUNK_SIZE
 // For best performance, should also be a power of 2
 #define BIOME_SIZE (CHUNK_SIZE * 8)

--- a/include/tools.h
+++ b/include/tools.h
@@ -36,6 +36,7 @@ void readString (int client_fd);
 
 uint32_t fast_rand ();
 uint64_t splitmix64 (uint64_t state);
+uint32_t splitmix32 (uint32_t state);
 
 #ifdef ESP_PLATFORM
   #include "esp_timer.h"

--- a/src/procedures.c
+++ b/src/procedures.c
@@ -657,7 +657,9 @@ uint8_t isInstantlyMined (PlayerData *player, uint8_t block) {
     block == B_short_grass ||
     block == B_torch ||
     block == B_lily_pad ||
-    block == B_oak_sapling
+    block == B_oak_sapling ||
+    block == B_poppy ||
+    block == B_dandelion
   );
 
 }
@@ -672,7 +674,9 @@ uint8_t isColumnBlock (uint8_t block) {
     block == B_dead_bush ||
     block == B_sand ||
     block == B_torch ||
-    block == B_oak_sapling
+    block == B_oak_sapling ||
+    block == B_poppy ||
+    block == B_dandelion
   );
 }
 
@@ -686,7 +690,9 @@ uint8_t isPassableBlock (uint8_t block) {
     block == B_moss_carpet ||
     block == B_short_grass ||
     block == B_dead_bush ||
-    block == B_torch
+    block == B_torch ||
+    block == B_poppy ||
+    block == B_dandelion
   );
 }
 // Checks whether the given block is non-solid and spawnable

--- a/src/tools.c
+++ b/src/tools.c
@@ -238,6 +238,15 @@ uint64_t splitmix64 (uint64_t state) {
   return z ^ (z >> 31);
 }
 
+// https://stackoverflow.com/a/52056161
+uint32_t splitmix32 (uint32_t state) {
+  uint32_t z = state + 0x9e3779b9;
+  z ^= z >> 16; z *= 0x21f0aaad;
+  z ^= z >> 15; z *= 0x735a2d97;
+  z ^= z >> 15;
+  return z;
+}
+
 #ifndef ESP_PLATFORM
 // Returns system time in microseconds.
 // On ESP-IDF, this is available in "esp_timer.h", and returns time *since

--- a/src/worldgen.c
+++ b/src/worldgen.c
@@ -297,7 +297,6 @@ uint8_t getTerrainAtFromCache (int x, int y, int z, int rx, int rz, ChunkAnchor 
       return B_snow;
     }
   }
-
   // Starting at 4 blocks below terrain level, generate minerals and caves
   if (y <= height - 4) {
     // Caves use the same shape as surface terrain, just mirrored

--- a/src/worldgen.c
+++ b/src/worldgen.c
@@ -200,7 +200,14 @@ uint8_t getTerrainAtFromCache (int x, int y, int z, int rx, int rz, ChunkAnchor 
 
       // Since we're sure that we're above sea level and in a plains biome,
       // there's no need to drop down to decide the surrounding blocks.
-      if (y == height) return B_grass_block;
+      // Spawn some flowers
+      if (y == height) {
+      if (((anchor.hash ^ x ^ z ^ y) & 15) == 0) return B_poppy;
+      if (((anchor.hash >> 8 ^ x ^ z ^ y) & 15) == 0) return B_dandelion;
+
+      return B_grass_block;
+      }
+
       return B_air;
     }
 

--- a/src/worldgen.c
+++ b/src/worldgen.c
@@ -200,9 +200,8 @@ uint8_t getTerrainAtFromCache (int x, int y, int z, int rx, int rz, ChunkAnchor 
 
       // Spawn some flowers
       if (y == height + 1) {
-      if (((anchor.hash ^ x ^ z ^ y) & 15) == 0) return B_poppy;
-      if (((anchor.hash >> 8 ^ x ^ z ^ y) & 15) == 0) return B_dandelion;
-
+      if (feature.variant == 0) return B_poppy;
+      if (feature.variant == 1) return B_dandelion;
       return B_grass_block;
       }
 

--- a/src/worldgen.c
+++ b/src/worldgen.c
@@ -198,16 +198,16 @@ uint8_t getTerrainAtFromCache (int x, int y, int z, int rx, int rz, ChunkAnchor 
         return B_oak_leaves;
       }
 
-      // Since we're sure that we're above sea level and in a plains biome,
-      // there's no need to drop down to decide the surrounding blocks.
       // Spawn some flowers
-      if (y == height) {
+      if (y == height + 1) {
       if (((anchor.hash ^ x ^ z ^ y) & 15) == 0) return B_poppy;
       if (((anchor.hash >> 8 ^ x ^ z ^ y) & 15) == 0) return B_dandelion;
 
       return B_grass_block;
       }
 
+
+      if (y == height) return B_grass_block;
       return B_air;
     }
 


### PR DESCRIPTION
Originally I was just playing around with the world generation and noticed that something was missing from the world. More vegetation! I then tried to add some flowers to the game, which is what this PR contains. Currently only flowers such as poppies and dandelions are supported, however I could also rename the 'getFlowerAt' function to 'getVegetationAt, so that the generation of dead bushes and grass can be moved there later as well.

As for the performance, I need someone with a very low end chip to test this. The lowest I could go is a 13 y/o dual core 1.8 GHz i3 processor to run the server, on which it worked perfectly fine. 

What do y'all think?