### PR TITLE
Fix Array OOB

### DIFF
--- a/src/procedures.c
+++ b/src/procedures.c
@@ -562,7 +562,7 @@ uint8_t makeBlockChange (short x, uint8_t y, short z, uint8_t block) {
     // By design, this loop also continues past the current search range,
     // which naturally appends the chest to the end if a gap isn't found.
     int last_real_entry = first_gap - 1;
-    for (int i = first_gap; i <= block_changes_count + 15; i ++) {
+    for (int i = first_gap; i <= block_changes_count + 15 && i < MAX_BLOCK_CHANGES; i ++) {
       if (block_changes[i].block != 0xFF) {
         last_real_entry = i;
         continue;


### PR DESCRIPTION
If `block_changes_count` is within 15 of `MAX_BLOCK_CHANGES` and the code can't find any other gap then it will OOB.

I don't have an ESP32 to benchmark the performance loss, though it's probably minimal.

Noticed this while considering what code I'd have to touch to implement that idea I had for looping through the `block_changes` to make a pseudorandom tick system for growing saplings, figured we should decide whether or not to fix that edge case before I make another pull request touching the same function.