### PR TITLE
Smooth mob interpolation with jump-style steps and predictable bandwidth knobs

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -249,6 +249,55 @@ typedef struct {
   uint8_t data;
 } MobData;
 
+// Pack the last horizontal movement delta into the upper bits of the x/z
+// coordinates. This avoids growing MobData while preserving previous
+// positions for interpolation. Valid block range: [-8192, 8191].
+#define MOB_COORD_OFFSET 8192
+#define MOB_COORD_MASK 0x3FFF
+
+static inline short mobBlockCoord (short packed) {
+  return (short)((packed & MOB_COORD_MASK) - MOB_COORD_OFFSET);
+}
+
+static inline int8_t mobDeltaCoord (short packed) {
+  return (int8_t)(((packed >> 14) & 3) - 1);
+}
+
+static inline short mobEncodeCoord (short block, int8_t delta) {
+  uint16_t base = (uint16_t)(block + MOB_COORD_OFFSET) & MOB_COORD_MASK;
+  uint16_t delta_bits = (uint16_t)(delta + 1) & 3;
+  return (short)(base | (delta_bits << 14));
+}
+
+static inline short mobBlockX (const MobData *mob) {
+  return mobBlockCoord(mob->x);
+}
+
+static inline short mobBlockZ (const MobData *mob) {
+  return mobBlockCoord(mob->z);
+}
+
+static inline int8_t mobDeltaX (const MobData *mob) {
+  return mobDeltaCoord(mob->x);
+}
+
+static inline int8_t mobDeltaZ (const MobData *mob) {
+  return mobDeltaCoord(mob->z);
+}
+
+static inline void mobSetX (MobData *mob, short block, int8_t delta) {
+  mob->x = mobEncodeCoord(block, delta);
+}
+
+static inline void mobSetZ (MobData *mob, short block, int8_t delta) {
+  mob->z = mobEncodeCoord(block, delta);
+}
+
+static inline void mobClearHorizontalDelta (MobData *mob) {
+  mob->x = mobEncodeCoord(mobBlockCoord(mob->x), 0);
+  mob->z = mobEncodeCoord(mobBlockCoord(mob->z), 0);
+}
+
 #pragma pack(pop)
 
 union EntityDataValue {

--- a/include/globals.h
+++ b/include/globals.h
@@ -293,6 +293,11 @@ static inline void mobSetZ (MobData *mob, short block, int8_t delta) {
   mob->z = mobEncodeCoord(block, delta);
 }
 
+static inline void mobClearHorizontalDelta (MobData *mob) {
+  mob->x = mobEncodeCoord(mobBlockCoord(mob->x), 0);
+  mob->z = mobEncodeCoord(mobBlockCoord(mob->z), 0);
+}
+
 static inline uint8_t mobBaseYaw (int8_t dx, int8_t dz) {
   if (dx < 0) {
     uint8_t yaw = 64;

--- a/include/globals.h
+++ b/include/globals.h
@@ -293,9 +293,22 @@ static inline void mobSetZ (MobData *mob, short block, int8_t delta) {
   mob->z = mobEncodeCoord(block, delta);
 }
 
-static inline void mobClearHorizontalDelta (MobData *mob) {
-  mob->x = mobEncodeCoord(mobBlockCoord(mob->x), 0);
-  mob->z = mobEncodeCoord(mobBlockCoord(mob->z), 0);
+static inline uint8_t mobBaseYaw (int8_t dx, int8_t dz) {
+  if (dx < 0) {
+    uint8_t yaw = 64;
+    if (dz < 0) return yaw + 32;
+    if (dz > 0) return yaw - 32;
+    return yaw;
+  }
+  if (dx > 0) {
+    uint8_t yaw = 192;
+    if (dz < 0) return yaw - 32;
+    if (dz > 0) return yaw + 32;
+    return yaw;
+  }
+  if (dz < 0) return 128;
+  if (dz > 0) return 0;
+  return 0;
 }
 
 #pragma pack(pop)

--- a/include/procedures.h
+++ b/include/procedures.h
@@ -51,6 +51,8 @@ void hurtEntity (int entity_id, int attacker_id, uint8_t damage_type, uint8_t da
 void handleServerTick (int64_t time_since_last_tick);
 void processMobInterpolation (int64_t now);
 float getMobInterpolationAlpha ();
+int8_t getMobPendingVerticalDelta (int mob_index);
+uint8_t getMobPendingYaw (int mob_index);
 
 void broadcastChestUpdate (int origin_fd, uint8_t *storage_ptr, uint16_t item, uint8_t count, uint8_t slot);
 

--- a/include/procedures.h
+++ b/include/procedures.h
@@ -49,6 +49,8 @@ void spawnMob (uint8_t type, short x, uint8_t y, short z, uint8_t health);
 void interactEntity (int entity_id, int interactor_id);
 void hurtEntity (int entity_id, int attacker_id, uint8_t damage_type, uint8_t damage);
 void handleServerTick (int64_t time_since_last_tick);
+void processMobInterpolation (int64_t now);
+float getMobInterpolationAlpha ();
 
 void broadcastChestUpdate (int origin_fd, uint8_t *storage_ptr, uint16_t item, uint8_t count, uint8_t slot);
 

--- a/include/procedures.h
+++ b/include/procedures.h
@@ -53,6 +53,8 @@ void processMobInterpolation (int64_t now);
 float getMobInterpolationAlpha ();
 int8_t getMobPendingVerticalDelta (int mob_index);
 uint8_t getMobPendingYaw (int mob_index);
+uint8_t getMobInterpolationPhase ();
+double sampleMobVerticalPosition (uint8_t current_y, int8_t delta_y, uint8_t phase);
 
 void broadcastChestUpdate (int origin_fd, uint8_t *storage_ptr, uint16_t item, uint8_t count, uint8_t slot);
 

--- a/src/main.c
+++ b/src/main.c
@@ -146,6 +146,7 @@ void handlePacket (int client_fd, int length, int packet_id, int state) {
         uint32_t r = fast_rand();
         memcpy(uuid, &r, 4);
         float mob_alpha = getMobInterpolationAlpha();
+        uint8_t mob_phase = getMobInterpolationPhase();
         // Send allocated living mobs, use ID for second half of UUID
         for (int i = 0; i < MAX_MOBS; i ++) {
           if (mob_data[i].type == 0) continue;
@@ -160,8 +161,7 @@ void handlePacket (int client_fd, int length, int packet_id, int state) {
           double prev_z = (double)(block_z - delta_z);
           double spawn_x = prev_x + (double)delta_x * mob_alpha + 0.5;
           double spawn_z = prev_z + (double)delta_z * mob_alpha + 0.5;
-          double prev_y = (double)mob_data[i].y - (double)delta_y;
-          double spawn_y = prev_y + (double)delta_y * mob_alpha;
+          double spawn_y = sampleMobVerticalPosition(mob_data[i].y, delta_y, mob_phase);
           uint8_t yaw_byte = getMobPendingYaw(i);
           if (yaw_byte == 0 && (delta_x != 0 || delta_z != 0)) {
             yaw_byte = mobBaseYaw(delta_x, delta_z);

--- a/src/main.c
+++ b/src/main.c
@@ -155,27 +155,23 @@ void handlePacket (int client_fd, int length, int packet_id, int state) {
           short block_z = mobBlockZ(&mob_data[i]);
           int8_t delta_x = mobDeltaX(&mob_data[i]);
           int8_t delta_z = mobDeltaZ(&mob_data[i]);
+          int8_t delta_y = getMobPendingVerticalDelta(i);
           double prev_x = (double)(block_x - delta_x);
           double prev_z = (double)(block_z - delta_z);
           double spawn_x = prev_x + (double)delta_x * mob_alpha + 0.5;
           double spawn_z = prev_z + (double)delta_z * mob_alpha + 0.5;
-          uint8_t yaw_byte = 0;
-          if (delta_x < 0) {
-            yaw_byte = 64;
-            if (delta_z < 0) yaw_byte += 32;
-            else if (delta_z > 0) yaw_byte -= 32;
-          } else if (delta_x > 0) {
-            yaw_byte = 192;
-            if (delta_z < 0) yaw_byte -= 32;
-            else if (delta_z > 0) yaw_byte += 32;
-          } else if (delta_z < 0) yaw_byte = 128;
-          else if (delta_z > 0) yaw_byte = 0;
+          double prev_y = (double)mob_data[i].y - (double)delta_y;
+          double spawn_y = prev_y + (double)delta_y * mob_alpha;
+          uint8_t yaw_byte = getMobPendingYaw(i);
+          if (yaw_byte == 0 && (delta_x != 0 || delta_z != 0)) {
+            yaw_byte = mobBaseYaw(delta_x, delta_z);
+          }
           // For more info on the arguments here, see the spawnMob function
           sc_spawnEntity(
             client_fd, -2 - i, uuid,
             mob_data[i].type,
             spawn_x,
-            mob_data[i].y,
+            spawn_y,
             spawn_z,
             yaw_byte * 360.0f / 256.0f,
             0

--- a/src/procedures.c
+++ b/src/procedures.c
@@ -2011,7 +2011,9 @@ void processMobInterpolation (int64_t now) {
       }
 
       if (alpha >= 1.0f) {
+        mobClearHorizontalDelta(&mob_data[i]);
         mob_interp_dy[i] = 0;
+        mob_interp_yaw[i] = 0;
       }
     }
 


### PR DESCRIPTION
Summary



1. Encode prior horizontal deltas inside MobData and cache tiny per-mob scratch buffers so we can interpolate movement without adding to the struct size.
2. Rework the tick loop to capture deltas, preserve panic headings, retry blocked moves, and queue interpolation phases only when something actually changes.
3. Add a lightweight interpolation scheduler (default 6 slices) that smooths horizontal motion, emits a discrete “hop” profile for vertical climbs/drops, and clears deltas/ yaw once the move settles to prevent snap-backs.2K tokens used   59% context left
4. Expose helpers so player joins spawn in-flight mobs at the correct interpolated position/yaw, and keep head rotation deterministic.

Goal: mimic Minecraft’s block-step feel with minimal RAM/CPU so an ESP32-hosted server stays responsive.

Memory impact
1. MobData remains unchanged.
2. New state: mob_interp_dy[MAX_MOBS] and mob_interp_yaw[MAX_MOBS] (1 byte each). With the default MAX_MOBS = 16, total additional RAM = 32 bytes.

Bandwidth impact
1. Each predicted slice still uses the standard Teleport Entity + Set Head Rotation packets (~78 B combined).
2. With MOB_INTERP_STEPS = 6, one move now emits up to 6 slices (~468 B) instead of 1 (~78 B). Idle mobs remain silent.

Config / tuning
1. MOB_INTERP_STEPS (in src/procedures.c) controls interpolation granularity. Lower values reduce bandwidth at the cost of choppier motion; 4–6 works well.
2. The vertical profile currently hops on the final two slices. Tweak mobVerticalProfile if you want a taller or earlier jump.
3. MOB_COORD_OFFSET/MASK constrain mob positions to +/-8192 blocks per axis, still well beyond what the ESP32 can serve.