### PR TITLE
Add a link to the mc protocol spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,5 @@ Alternatively, if you can't set up a file system, you can dump and upload world 
 - Create issues and discuss with the maintainer(s) before making pull requests.
 - Follow the existing code style. Ensure that your changes fit in with the surrounding code, even if you disagree with the style. Pull requests with inconsistent style will be nitpicked.
 - Test your code before creating a pull request or requesting a review, regardless of how "simple" your change is. It's a basic form of respect towards the maintainer and reviewer.
-- Development tooling and compilation improvements _are not welcome,_ unless you've worked with the codebase long enough to have noticed practical shortcomings in that area. I'm tired of receiving tooling PRs from people who don't intend to work with those tools.
+- Development tooling and compilation improvements *are not welcome,* unless you've worked with the codebase long enough to have noticed practical shortcomings in that area. I'm tired of receiving tooling PRs from people who don't intend to work with those tools.
+- The [Java Edition protocol specs](https://minecraft.wiki/w/Java_Edition_protocol/Entity_metadata) could prove useful for you


### PR DESCRIPTION
This is useful to potential contributors if they don't know where to look for the internal IDs without them having to look at the decompiled source
