### PR TITLE
Add whitelist and rework command system

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -1,0 +1,17 @@
+#ifndef COMMANDS_H
+#define COMMANDS_H
+
+#include "globals.h"
+#include "packets.h"
+#include "procedures.h"
+
+char *getArgument ();
+char *getRemainingArguments ();
+void handleCommand (PlayerData *sender, int message_len);
+#ifdef WHITELIST
+  void handleWhitelistCommand (PlayerData *sender);
+#endif
+void handleMessageCommand (PlayerData *sender);
+void handleHelpCommand (PlayerData *sender);
+
+#endif

--- a/include/commands.h
+++ b/include/commands.h
@@ -5,7 +5,7 @@
 #include "packets.h"
 #include "procedures.h"
 
-char *getArgument ();
+char *getNextArgument ();
 char *getRemainingArguments ();
 void handleCommand (PlayerData *sender, int message_len);
 #ifdef WHITELIST

--- a/include/globals.h
+++ b/include/globals.h
@@ -148,6 +148,13 @@
 // If defined, players are able to receive damage from nearby cacti.
 #define ENABLE_CACTUS_DAMAGE
 
+// If defined, enables whitelist commands and functionality to prevent automated server scraping.
+// #define WHITELIST
+
+#ifdef WHITELIST
+  #define MAX_WHITELISTED_PLAYERS 8
+#endif
+
 // If defined, logs unrecognized packet IDs
 // #define DEV_LOG_UNKNOWN_PACKETS
 
@@ -184,6 +191,11 @@ extern uint8_t motd_len;
 #ifdef SEND_BRAND
   extern char brand[];
   extern uint8_t brand_len;
+#endif
+
+#ifdef WHITELIST
+  extern uint8_t enforce_whitelist;
+  extern char whitelisted_players[16][MAX_WHITELISTED_PLAYERS];
 #endif
 
 extern uint16_t client_count;

--- a/include/procedures.h
+++ b/include/procedures.h
@@ -12,9 +12,16 @@ int getClientState (int client_fd);
 int getClientIndex (int client_fd);
 
 void resetPlayerData (PlayerData *player);
+
+#ifdef WHITELIST
+  uint8_t isPlayerWhitelisted (char *name);
+  uint8_t addPlayerToWhitelist (char *name);
+  uint8_t removePlayerFromWhitelist (char *name);
+#endif
+
 int reservePlayerData (int client_fd, uint8_t *uuid, char* name);
 int getPlayerData (int client_fd, PlayerData **output);
-PlayerData *getPlayerByName (int start_offset, int end_offset, uint8_t *buffer);
+PlayerData *getPlayerByName (char *name, uint8_t *buffer);
 void handlePlayerDisconnect (int client_fd);
 void handlePlayerJoin (PlayerData* player);
 void disconnectClient (int *client_fd, int cause);

--- a/src/commands.c
+++ b/src/commands.c
@@ -31,7 +31,7 @@ cleanup:
 }
 
 // Pulls a single space-delimited argument from the chat buffer
-char *getArgument () {
+char *getNextArgument () {
   return strtok(NULL, " ");
 }
 
@@ -42,7 +42,7 @@ char *getRemainingArguments () {
 
 #ifdef WHITELIST
 void handleWhitelistCommand (PlayerData *player) {
-  char *first_arg = getArgument();
+  char *first_arg = getNextArgument();
 
   if (first_arg == NULL) {
     goto usage;
@@ -57,7 +57,7 @@ void handleWhitelistCommand (PlayerData *player) {
     enforce_whitelist = 0;
     return;
   } else if (!strcmp(first_arg, "add")) {
-    char* player_arg = getArgument();
+    char* player_arg = getNextArgument();
     if (player_arg == NULL) {
       goto usage;
     }
@@ -76,7 +76,7 @@ void handleWhitelistCommand (PlayerData *player) {
     }
     return;
   } else if (!strcmp(first_arg, "remove")) {
-    char* player_arg = getArgument();
+    char* player_arg = getNextArgument();
     if (player_arg == NULL) {
       goto usage;
     }
@@ -115,7 +115,7 @@ usage:
 #endif
 
 void handleMessageCommand (PlayerData* player) {
-  char* target_name = getArgument();
+  char* target_name = getNextArgument();
 
   // Send usage guide if arguments are missing
   if (target_name == NULL) goto usage;

--- a/src/commands.c
+++ b/src/commands.c
@@ -9,7 +9,7 @@ void handleCommand (PlayerData *player, int message_len) {
     goto cleanup;
   }
 
-  char* command = strtok(recv_buffer, " ");
+  char* command = strtok((char *)recv_buffer, " ");
   #ifdef WHITELIST
   if (!strcmp(command, "!whitelist")) {
     handleWhitelistCommand(player);
@@ -92,13 +92,13 @@ void handleWhitelistCommand (PlayerData *player) {
     }
     return;
   } else if (!strcmp(first_arg, "list")) {
-    snprintf(recv_buffer, sizeof(recv_buffer), "§7The currently whitelisted players are:");
+    snprintf((char *)recv_buffer, sizeof(recv_buffer), "§7The currently whitelisted players are:");
     recv_buffer[41] = ' ';
     int length = 42;
     for (int i = 0; i < MAX_WHITELISTED_PLAYERS; i++) {
       if(whitelisted_players[i][0] == '\0') continue;
 
-      snprintf(recv_buffer + length, sizeof(recv_buffer) - length, "%s, ", whitelisted_players[i]);
+      snprintf((char *)recv_buffer + length, sizeof(recv_buffer) - length, "%s, ", whitelisted_players[i]);
       length += strlen(whitelisted_players[i]) + 2;
     }
     if(length == 42){
@@ -106,7 +106,7 @@ void handleWhitelistCommand (PlayerData *player) {
         return;
     }
     // Subtract 2 from the length to remove the trailing comma and space
-    sc_systemChat(player->client_fd, recv_buffer, length - 2);
+    sc_systemChat(player->client_fd, (char *)recv_buffer, length - 2);
     return;
   }
 usage:

--- a/src/commands.c
+++ b/src/commands.c
@@ -1,0 +1,170 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "globals.h"
+#include "commands.h"
+
+void handleCommand (PlayerData *player, int message_len) {
+  if (message_len <= 1) {
+    goto cleanup;
+  }
+
+  char* command = strtok(recv_buffer, " ");
+  #ifdef WHITELIST
+  if (!strcmp(command, "!whitelist")) {
+    handleWhitelistCommand(player);
+    return;
+  }
+  #endif
+  if (!strcmp((char *) command, "!msg")) {
+    handleMessageCommand(player);
+    return;
+  }
+  if (!strcmp((char *) command, "!help")) {
+    handleHelpCommand(player);
+    return;
+  }
+
+cleanup:
+  // Handle fall-through case
+  sc_systemChat(player->client_fd, "§7Unknown command. Type !help for help.", 40);
+}
+
+// Pulls a single space-delimited argument from the chat buffer
+char *getArgument () {
+  return strtok(NULL, " ");
+}
+
+// Pulls the remaining text from the chat buffer
+char *getRemainingArguments () {
+  return strtok(NULL, "");
+}
+
+#ifdef WHITELIST
+void handleWhitelistCommand (PlayerData *player) {
+  char *first_arg = getArgument();
+
+  if (first_arg == NULL) {
+    goto usage;
+  }
+
+  if (!strcmp(first_arg, "on")) {
+    sc_systemChat(player->client_fd, "§aWhitelist has been enabled", 29);
+    enforce_whitelist = 1;
+    return;
+  } else if (!strcmp(first_arg, "off")) {
+    sc_systemChat(player->client_fd, "§cWhitelist has been disabled", 30);
+    enforce_whitelist = 0;
+    return;
+  } else if (!strcmp(first_arg, "add")) {
+    char* player_arg = getArgument();
+    if (player_arg == NULL) {
+      goto usage;
+    }
+    int player_len = strlen(player_arg);
+    if (player_len < 3 || player_len > 16) {
+        sc_systemChat(player->client_fd, "§cError: input username is invalid", 35);
+        return;
+    }
+    int result = addPlayerToWhitelist(player_arg);
+    if(result == 0) {
+      sc_systemChat(player->client_fd, "§7Successfully added player to the whitelist", 45);
+    } else if(result == 1) {
+      sc_systemChat(player->client_fd, "§cError: Player is already on the whitelist", 44);
+    } else {
+      sc_systemChat(player->client_fd, "§cError: The whitelist is full, remove other players first then try again", 74);
+    }
+    return;
+  } else if (!strcmp(first_arg, "remove")) {
+    char* player_arg = getArgument();
+    if (player_arg == NULL) {
+      goto usage;
+    }
+    int player_len = strlen(player_arg);
+    if (player_len < 3 || player_len > 16) {
+        sc_systemChat(player->client_fd, "§cError: input username is invalid", 35);
+        return;
+    }
+    if(removePlayerFromWhitelist(player_arg) == 0) {
+      sc_systemChat(player->client_fd, "§7Successfully removed player from the whitelist", 49);
+    } else {
+      sc_systemChat(player->client_fd, "§cError: Player is not on the whitelist", 40);
+    }
+    return;
+  } else if (!strcmp(first_arg, "list")) {
+    snprintf(recv_buffer, sizeof(recv_buffer), "§7The currently whitelisted players are:");
+    recv_buffer[41] = ' ';
+    int length = 42;
+    for (int i = 0; i < MAX_WHITELISTED_PLAYERS; i++) {
+      if(whitelisted_players[i][0] == '\0') continue;
+
+      snprintf(recv_buffer + length, sizeof(recv_buffer) - length, "%s, ", whitelisted_players[i]);
+      length += strlen(whitelisted_players[i]) + 2;
+    }
+    if(length == 42){
+        sc_systemChat(player->client_fd, "§7There are currently no whitelisted players", 45);
+        return;
+    }
+    // Subtract 2 from the length to remove the trailing comma and space
+    sc_systemChat(player->client_fd, recv_buffer, length - 2);
+    return;
+  }
+usage:
+  sc_systemChat(player->client_fd, "§7Usage: !whitelist <on|off|add|remove> [username]", 51);
+}
+#endif
+
+void handleMessageCommand (PlayerData* player) {
+  char* target_name = getArgument();
+
+  // Send usage guide if arguments are missing
+  if (target_name == NULL) goto usage;
+
+  // Query the target player
+  PlayerData *target = getPlayerByName(target_name, recv_buffer);
+  if (target == NULL) {
+    sc_systemChat(player->client_fd, "Player not found", 16);
+    return;
+  }
+
+  char *message = getRemainingArguments();
+
+  // Don't send empty messages
+  if (message == NULL) goto usage;
+
+  // Format output as a vanilla whisper
+  int name_len = strlen(player->name);
+  int text_len = strlen(message);
+  memmove(recv_buffer + name_len + 24, message, text_len);
+  snprintf((char *)recv_buffer, sizeof(recv_buffer), "§7§o%s whispers to you:", player->name);
+
+  // snprintf always null terminates strings, so we get rid of that here
+  recv_buffer[name_len + 23] = ' ';
+
+  // Send message to target player
+  sc_systemChat(target->client_fd, (char *)recv_buffer, (uint16_t)(name_len + 24 + text_len));
+
+  // Format output for sending player
+  int target_name_len = strlen(target->name);
+  memmove(recv_buffer + target_name_len + 23, recv_buffer + name_len + 24, text_len);
+  snprintf((char *)recv_buffer, sizeof(recv_buffer), "§7§oYou whisper to %s:", target->name);
+  recv_buffer[target_name_len + 22] = ' ';
+
+  // Report back to sending player
+  sc_systemChat(player->client_fd, (char *)recv_buffer, (uint16_t)(target_name_len + 23 + text_len));
+  return;
+
+usage:
+  sc_systemChat(player->client_fd, "§7Usage: !msg <player> <message>", 33);
+}
+
+void handleHelpCommand (PlayerData *player) {
+  // Send command guide
+  const char help_msg[] = "§7Commands:\n"
+  "  !msg <player> <message> - Send a private message\n"
+  #ifdef WHITELIST
+  "  !whitelist <on|off|add|remove> [username]\n"
+  #endif
+  "  !help - Show this help message";
+  sc_systemChat(player->client_fd, (char *)help_msg, (uint16_t)sizeof(help_msg) - 1);
+}

--- a/src/globals.c
+++ b/src/globals.c
@@ -45,6 +45,11 @@ uint8_t motd_len = sizeof(motd) - 1;
   uint8_t brand_len = sizeof(brand) - 1;
 #endif
 
+#ifdef WHITELIST
+  uint8_t enforce_whitelist = 0;
+  char whitelisted_players[16][MAX_WHITELISTED_PLAYERS];
+#endif
+
 uint16_t client_count;
 
 BlockChange block_changes[MAX_BLOCK_CHANGES];

--- a/src/main.c
+++ b/src/main.c
@@ -81,6 +81,13 @@ void handlePacket (int client_fd, int length, int packet_id, int state) {
         uint8_t uuid[16];
         char name[16];
         if (cs_loginStart(client_fd, uuid, name)) break;
+        #ifdef WHITELIST
+        if (enforce_whitelist && !isPlayerWhitelisted(name)) {
+          printf("Disconnecting client %d because they are not on the whitelist\n", client_fd);
+          recv_count = 0;
+          return;
+        }
+        #endif
         if (reservePlayerData(client_fd, uuid, name)) {
           recv_count = 0;
           return;

--- a/src/packets.c
+++ b/src/packets.c
@@ -23,6 +23,7 @@
 #include "crafting.h"
 #include "procedures.h"
 #include "packets.h"
+#include "commands.h"
 
 // S->C Status Response (server list ping)
 int sc_statusResponse (int client_fd) {
@@ -1143,67 +1144,7 @@ int cs_chat (int client_fd) {
     goto cleanup;
   }
 
-  // Handle chat commands
-
-  if (!strncmp((char *)recv_buffer, "!msg", 4)) {
-
-    int target_offset = 5;
-    int target_end_offset = 0;
-    int text_offset = 0;
-
-    // Skip spaces after "!msg"
-    while (recv_buffer[target_offset] == ' ') target_offset++;
-    target_end_offset = target_offset;
-    // Extract target name
-    while (recv_buffer[target_end_offset] != ' ' && recv_buffer[target_end_offset] != '\0' && target_end_offset < 21) target_end_offset++;
-    text_offset = target_end_offset;
-    // Skip spaces before message
-    while (recv_buffer[text_offset] == ' ') text_offset++;
-
-    // Send usage guide if arguments are missing
-    if (target_offset == target_end_offset || target_end_offset == text_offset) {
-      sc_systemChat(client_fd, "§7Usage: !msg <player> <message>", 33);
-      goto cleanup;
-    }
-
-    // Query the target player
-    PlayerData *target = getPlayerByName(target_offset, target_end_offset, recv_buffer);
-    if (target == NULL) {
-      sc_systemChat(client_fd, "Player not found", 16);
-      goto cleanup;
-    }
-
-    // Format output as a vanilla whisper
-    int name_len = strlen(player->name);
-    int text_len = message_len - text_offset;
-    memmove(recv_buffer + name_len + 24, recv_buffer + text_offset, text_len);
-    snprintf((char *)recv_buffer, sizeof(recv_buffer), "§7§o%s whispers to you:", player->name);
-    recv_buffer[name_len + 23] = ' ';
-    // Send message to target player
-    sc_systemChat(target->client_fd, (char *)recv_buffer, (uint16_t)(name_len + 24 + text_len));
-
-    // Format output for sending player
-    int target_len = target_end_offset - target_offset;
-    memmove(recv_buffer + target_len + 23, recv_buffer + name_len + 24, text_len);
-    snprintf((char *)recv_buffer, sizeof(recv_buffer), "§7§oYou whisper to %s:", target->name);
-    recv_buffer[target_len + 22] = ' ';
-    // Report back to sending player
-    sc_systemChat(client_fd, (char *)recv_buffer, (uint16_t)(target_len + 23 + text_len));
-
-    goto cleanup;
-  }
-
-  if (!strncmp((char *)recv_buffer, "!help", 5)) {
-    // Send command guide
-    const char help_msg[] = "§7Commands:\n"
-    "  !msg <player> <message> - Send a private message\n"
-    "  !help - Show this help message";
-    sc_systemChat(client_fd, (char *)help_msg, (uint16_t)sizeof(help_msg) - 1);
-    goto cleanup;
-  }
-
-  // Handle fall-through case
-  sc_systemChat(client_fd, "§7Unknown command", 18);
+  handleCommand(player, message_len);
 
 cleanup:
   readUint64(client_fd); // Ignore timestamp

--- a/src/procedures.c
+++ b/src/procedures.c
@@ -175,13 +175,6 @@ PlayerData *getPlayerByName (char *name, uint8_t *buffer) {
     if (!strcmp(player_data[i].name, name)) {
       return &player_data[i];
     }
-    // int j;
-    // for (j = start_offset; j < end_offset && j < 256 && buffer[j] != ' '; j++) {
-    //   if (player_data[i].name[j - start_offset] != buffer[j]) break;
-    // }
-    // if ((j == end_offset || buffer[j] == ' ') && j < 256) {
-    //   return &player_data[i];
-    // }
   }
   return NULL;
 }


### PR DESCRIPTION
Closes #92

- This PR adds commands for turning the whitelist on and off, adding and removing players from the whitelist, and viewing which players are on the whitelist. 
- Whitelisted players are not persisted and are cleared on a restart. 
- There is a hard limit of 8 players on the whitelist, at which point other players must be manually removed to make room for new players. 
- If a player is not whitelisted, they are disconnected when the client sends the login start packet and see 'Disconnected' on their game client.

This PR also reworks the command system to make it easier to add new commands in the future.

The memory impact of this change is 128 bytes for storing the 8 whitelisted players and another byte for toggling the whitelist on and off.

Tested on a ESP32-WROOM-32 dev board.