### PR TITLE
Improve MinGW compatibility

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -712,7 +712,11 @@ int main () {
     }
     // Handle packet data
     handlePacket(client_fd, length - sizeVarInt(packet_id), packet_id, state);
-    if (recv_count == 0 || (recv_count == -1 && errno != EAGAIN && errno != EWOULDBLOCK)) {
+	#ifdef _WIN32
+      if (recv_count == 0 || (recv_count == -1 && WSAGetLastError() != WSAEWOULDBLOCK)) {
+    #else
+      if (recv_count == 0 || (recv_count == -1 && errno != EAGAIN && errno != EWOULDBLOCK)) {
+    #endif
       disconnectClient(&clients[client_index], 4);
       continue;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -712,7 +712,7 @@ int main () {
     }
     // Handle packet data
     handlePacket(client_fd, length - sizeVarInt(packet_id), packet_id, state);
-	#ifdef _WIN32
+    #ifdef _WIN32
       if (recv_count == 0 || (recv_count == -1 && WSAGetLastError() != WSAEWOULDBLOCK)) {
     #else
       if (recv_count == 0 || (recv_count == -1 && errno != EAGAIN && errno != EWOULDBLOCK)) {

--- a/src/tools.c
+++ b/src/tools.c
@@ -289,8 +289,15 @@ uint64_t splitmix64 (uint64_t state) {
 // the start of the program*, and NOT wall clock time. To ensure
 // compatibility, this should only be used to measure time intervals.
 int64_t get_program_time () {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return (int64_t)ts.tv_sec * 1000000LL + ts.tv_nsec / 1000LL;
+  #ifdef _WIN32
+    LARGE_INTEGER frequency, counter;
+    QueryPerformanceFrequency(&frequency);
+    QueryPerformanceCounter(&counter);
+    return (int64_t)(counter.QuadPart * 1000000LL / frequency.QuadPart);
+  #else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t)ts.tv_sec * 1000000LL + ts.tv_nsec / 1000LL;
+  #endif
 }
 #endif

--- a/src/tools.c
+++ b/src/tools.c
@@ -53,7 +53,7 @@ ssize_t recv_all (int client_fd, void *buf, size_t n, uint8_t require_first) {
   if (require_first) {
     ssize_t r = recv(client_fd, p, 1, MSG_PEEK);
     if (r <= 0) {
-	    #ifdef _WIN32
+        #ifdef _WIN32
         if (r < 0 && (WSAGetLastError() == WSAEWOULDBLOCK)) {
       #else
         if (r < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
@@ -68,7 +68,7 @@ ssize_t recv_all (int client_fd, void *buf, size_t n, uint8_t require_first) {
   while (total < n) {
     ssize_t r = recv(client_fd, p + total, n - total, 0);
     if (r < 0) {
-	    #ifdef _WIN32
+        #ifdef _WIN32
         if (WSAGetLastError() == WSAEWOULDBLOCK) {
       #else
         if (errno == EAGAIN || errno == EWOULDBLOCK) {

--- a/src/tools.c
+++ b/src/tools.c
@@ -53,7 +53,7 @@ ssize_t recv_all (int client_fd, void *buf, size_t n, uint8_t require_first) {
   if (require_first) {
     ssize_t r = recv(client_fd, p, 1, MSG_PEEK);
     if (r <= 0) {
-        #ifdef _WIN32
+      #ifdef _WIN32
         if (r < 0 && (WSAGetLastError() == WSAEWOULDBLOCK)) {
       #else
         if (r < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
@@ -68,7 +68,7 @@ ssize_t recv_all (int client_fd, void *buf, size_t n, uint8_t require_first) {
   while (total < n) {
     ssize_t r = recv(client_fd, p + total, n - total, 0);
     if (r < 0) {
-        #ifdef _WIN32
+      #ifdef _WIN32
         if (WSAGetLastError() == WSAEWOULDBLOCK) {
       #else
         if (errno == EAGAIN || errno == EWOULDBLOCK) {


### PR DESCRIPTION
This makes bareiron be able to be compiled for Windows by using WSA alternatives for connection data and having a custom implementation for `get_program_time` for Windows/NT platforms.
Also this was a pain to make and debug lol

Proof:
![image](https://github.com/user-attachments/assets/e6fe9455-c322-46e8-a4a5-d7106aa7c3e8)
