### PR TITLE
Add `-s` flag to strip symbols

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,5 +41,5 @@ for arg in "$@"; do
 done
 
 rm -f "bareiron$exe"
-$compiler src/*.c -O3 -Iinclude -o "bareiron$exe" $windows_linker
+$compiler src/*.c -O3 -s -Iinclude -o "bareiron$exe" $windows_linker
 "./bareiron$exe"


### PR DESCRIPTION
The resulting binary is ~38.5% smaller (Windows x64) / ~10.4% smaller (Linux ARM64). Might not be desired since it can help with debugging, but for running the project, definitely something worth looking at.