### PR TITLE
Feat/creepers

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -162,6 +162,9 @@
 // Doesn't implement authentication, hence disabled by default.
 // #define DEV_ENABLE_BEEF_DUMPS
 
+// If defined, mobs are allowed to affect terrain
+#define MOB_GRIEFING
+
 #define STATE_NONE 0
 #define STATE_STATUS 1
 #define STATE_LOGIN 2

--- a/include/globals.h
+++ b/include/globals.h
@@ -256,12 +256,13 @@ typedef struct {
 
 union EntityDataValue {
   uint8_t byte;
-  int pose;
+  int varint; // Also used for poses
 };
 
 typedef struct {
   uint8_t index;
   // 0 - Byte
+  // 1 - VarInt
   // 21 - Pose
   int type;
   union EntityDataValue value;

--- a/include/structures.h
+++ b/include/structures.h
@@ -2,5 +2,6 @@
 #define H_STRUCTURES
 
 void placeTreeStructure (short x, uint8_t y, short z);
+void placeCraterStructure (short x, uint8_t y, short z, uint8_t radius);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -377,14 +377,15 @@ void handlePacket (int client_fd, int length, int packet_id, int state) {
           if (mob_y != 255) {
             // Spawn passive mobs above ground during the day,
             // or hostiles underground and during the night
+            uint32_t mob_choice = (r >> 12) & 3;
             if ((world_time < 13000 || world_time > 23460) && mob_y > 48) {
-              uint32_t mob_choice = (r >> 12) & 3;
               if (mob_choice == 0) spawnMob(25, mob_x, mob_y, mob_z, 4); // Chicken
               else if (mob_choice == 1) spawnMob(28, mob_x, mob_y, mob_z, 10); // Cow
               else if (mob_choice == 2) spawnMob(95, mob_x, mob_y, mob_z, 10); // Pig
               else if (mob_choice == 3) spawnMob(106, mob_x, mob_y, mob_z, 8); // Sheep
             } else {
-              spawnMob(145, mob_x, mob_y, mob_z, 20); // Zombie
+              if (mob_choice == 0) spawnMob(30, mob_x, mob_y, mob_z, 20); // Creeper
+              else if (mob_choice > 0) spawnMob(145, mob_x, mob_y, mob_z, 20); // Zombie
             }
           }
         }

--- a/src/procedures.c
+++ b/src/procedures.c
@@ -1574,6 +1574,7 @@ void hurtEntity (int entity_id, int attacker_id, uint8_t damage_type, uint8_t da
         switch (mob->type) {
           case 25: givePlayerItem(player, I_chicken, 1); break;
           case 28: givePlayerItem(player, I_beef, 1 + (fast_rand() % 3)); break;
+          case 30: givePlayerItem(player, I_gunpowder, (fast_rand() % 3)); break;
           case 95: givePlayerItem(player, I_porkchop, 1 + (fast_rand() % 3)); break;
           case 106: givePlayerItem(player, I_mutton, 1 + (fast_rand() & 1)); break;
           case 145: givePlayerItem(player, I_rotten_flesh, (fast_rand() % 3)); break;
@@ -1713,12 +1714,17 @@ void handleServerTick (int64_t time_since_last_tick) {
       mob_data[i].type == 95 || // Pig
       mob_data[i].type == 106 // Sheep
     );
+
+    uint8_t burns_in_sunlight = ( // Not all "undead" burn in sun
+      mob_data[i].type == 145 // Zombie
+    );
+
     // Mob "panic" timer, set to 3 after being hit
     // Currently has no effect on hostile mobs
     uint8_t panic = (mob_data[i].data >> 6) & 3;
 
     // Burn hostile mobs if above ground during sunlight
-    if (!passive && (world_time < 13000 || world_time > 23460) && mob_data[i].y > 48) {
+    if (burns_in_sunlight && (world_time < 13000 || world_time > 23460) && mob_data[i].y > 48) {
       hurtEntity(entity_id, -1, D_on_fire, 2);
     }
 

--- a/src/procedures.c
+++ b/src/procedures.c
@@ -1797,8 +1797,11 @@ void handleServerTick (int64_t time_since_last_tick) {
         switch (mob_data[i].type) {
           case 30: // Creeper
             if (panic){
-              // Explode
+              // Explode and deal damage
+              #ifdef MOB_GRIEFING
               placeCraterStructure(mob_data[i].x, mob_data[i].y + 1, mob_data[i].z, 3);
+              #endif
+
               for (int j = 0; j < MAX_PLAYERS; j ++) {
                 if (player_data[j].client_fd == -1) continue;
                 uint16_t curr_dist = (

--- a/src/procedures.c
+++ b/src/procedures.c
@@ -431,6 +431,18 @@ void broadcastMobMetadata (int client_fd, int entity_id) {
   size_t length;
 
   switch (mob->type) {
+    case 30: // Creeper
+      int fuse;
+      if ((mob->data >> 6) & 3) fuse = 1;
+      else fuse = -1;
+      metadata = malloc(sizeof *metadata);
+      metadata[0] = (EntityData){
+        16,                  // Index (Fuse)
+        1,                   // Type (VarInt)
+        { .varint = fuse },  // Value
+      };
+      length = 1;
+      break;
     case 106: // Sheep
       if (!((mob->data >> 5) & 1)) // Don't send metadata if sheep isn't sheared
         return;
@@ -1825,6 +1837,7 @@ void handleServerTick (int64_t time_since_last_tick) {
               mob_data[i].type = 0;
             } else {
               mob_data[i].data += (1 << 6);
+              broadcastMobMetadata(-1, entity_id);
             }
             continue;
           default: break;
@@ -1834,6 +1847,7 @@ void handleServerTick (int64_t time_since_last_tick) {
       // Creeper defuse
       if (mob_data[i].type == 30 && panic && (closest_dist >= 5 || !close_on_y_axis)) {
         mob_data[i].data &= 0x3F;
+        broadcastMobMetadata(-1, entity_id);
         continue;
       }
 
@@ -1981,8 +1995,9 @@ ssize_t writeEntityData (int client_fd, EntityData *data) {
   switch (data->type) {
     case 0: // Byte
       return writeByte(client_fd, data->value.byte);
+    case 1: // VarInt
     case 21: // Pose
-      writeVarInt(client_fd, data->value.pose);
+      writeVarInt(client_fd, data->value.varint);
       return 0;
 
     default: return -1;
@@ -1997,8 +2012,9 @@ int sizeEntityData (EntityData *data) {
     case 0: // Byte
       value_size = 1;
       break;
+    case 1: // VarInt
     case 21: // Pose
-      value_size = sizeVarInt(data->value.pose);
+      value_size = sizeVarInt(data->value.varint);
       break;
 
     default: return -1;

--- a/src/procedures.c
+++ b/src/procedures.c
@@ -1718,9 +1718,9 @@ void handleServerTick (int64_t time_since_last_tick) {
       mob_data[i].type == 95 || // Pig
       mob_data[i].type == 106 // Sheep
     );
-
-    // Mob "panic" timer, set to 3 after being hit
-    // Currently has no effect on hostile mobs
+    // Mob "panic" timer
+    // For passive mobs, set to 3 after being hit
+    // For hostile mobs may vary. Represents creeper fuse timer.
     uint8_t panic = (mob_data[i].data >> 6) & 3;
 
     // Burn hostile burnable mobs if above ground during sunlight
@@ -1790,18 +1790,24 @@ void handleServerTick (int64_t time_since_last_tick) {
         else { new_z -= 1; yaw = 128; }
       }
 
-    } else { // Hostile mob movement handling
+    } else { // Hostile mob movement handling and attacks
 
-      // If we're already next to the player, do an attack and skip movement
-      if (closest_dist < 3 && abs(old_y - closest_player->y) < 2) {
+      // Attack checks. If successful, also skip movement.
+      // Close melee attacks (~2 blocks)
+      bool close_on_y_axis = abs(old_y - closest_player->y) < 2;
+      if (closest_dist < 3 && close_on_y_axis) {
+        switch (mob_data[i].type) {
+          case 145: hurtEntity(closest_player->client_fd, entity_id, D_generic, 6); continue; // Zombie
+          default: break;
+        }
+      }
+
+      // Middle-range attacks (~4 blocks)
+      if (closest_dist < 5 && close_on_y_axis) {
         switch (mob_data[i].type) {
           case 30: // Creeper
             if (panic){
               // Explode and deal damage
-              #ifdef MOB_GRIEFING
-              placeCraterStructure(mob_data[i].x, mob_data[i].y + 1, mob_data[i].z, 3);
-              #endif
-
               for (int j = 0; j < MAX_PLAYERS; j ++) {
                 if (player_data[j].client_fd == -1) continue;
                 uint16_t curr_dist = (
@@ -1809,18 +1815,26 @@ void handleServerTick (int64_t time_since_last_tick) {
                   abs(mob_data[i].z - player_data[j].z)
                 );
                 // Attack every player in area of explosion
-                if (curr_dist <= 3) hurtEntity(player_data[j].client_fd, entity_id, D_explosion, 10);
+                if (curr_dist < 5) hurtEntity(player_data[j].client_fd, entity_id, D_explosion, 10);
                 // Broadcast creeper disappearance from all players
                 sc_removeEntity(player_data[j].client_fd, entity_id);
               }
+              #ifdef MOB_GRIEFING
+              placeCraterStructure(mob_data[i].x, mob_data[i].y + 1, mob_data[i].z, 3);
+              #endif
               mob_data[i].type = 0;
             } else {
               mob_data[i].data += (1 << 6);
             }
             continue;
-          case 145: hurtEntity(closest_player->client_fd, entity_id, D_generic, 6); continue; // Zombie
-          default: continue;
+          default: break;
         }
+      }
+
+      // Creeper defuse
+      if (mob_data[i].type == 30 && panic && (closest_dist >= 5 || !close_on_y_axis)) {
+        mob_data[i].data &= 0x3F;
+        continue;
       }
 
       // Move towards the closest player on 8 axis

--- a/src/structures.c
+++ b/src/structures.c
@@ -53,3 +53,28 @@ void placeTreeStructure (short x, uint8_t y, short z) {
   }
 
 }
+
+// Places an explosion crater centered on the input coordinates
+void placeCraterStructure (short x, uint8_t y, short z, uint8_t radius) {
+  int radius_sq = radius * radius;
+  
+  // Air blocks are placed in a sphere
+  // Starting with y to check for height bounds
+  for (int dy = -radius; dy <= radius; dy++) {
+    if (y + dy < 0 || y + dy > 255) continue;
+    int dy_sq = dy * dy;
+    for (int dx = -radius; dx <= radius; dx++) {
+      int dx_sq = dx * dx;
+      for (int dz = -radius; dz <= radius; dz++) {
+        int dist_sq = dx_sq + dy_sq + (dz * dz);
+        if (dist_sq <= radius_sq) {
+          // Don't replace what is already air
+          uint8_t current_block = getBlockAt(x + dx, y + dy, z + dz);
+          if (current_block != B_air) {
+            makeBlockChange(x + dx, y + dy, z + dz, B_air);
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #69 
I saw that this issue was stale for a while, so I decided to tackle it.
Feel free to check out. I'd say it's mostly, if not fully, complete, with explosions, behaviour under the sun, and all that. I also added an explosion death message and a MOB_GRIEFING global, as it just seemed right.

However, I want to discuss a couple of questions to possibly improve this further.
1. Right now, the creeper only damages the nearby players. Should it be expanded to all nearby mobs? Kinda scared about efficiency here. It's not like there's hordes of mobs loaded, I know, but still...
2. Caboom timing. Right now, it's a couple of seconds, ~~and only if the player is standing completely still - I haven't touched the movement code. So, it's pretty easy to avoid being exploded (given you noticed them in advance with their complete silence :D)  Should it be altered for a more classic behaviour? Just wanna hear some feedback how it feels.~~ Altered it to a more fair behaviour.
3. Damage. Right now it's 5 hearts. Maybe pump it to like ~10? The fact that there's no sounds and no item drops would make an insta-kill or a near insta-kill quite unforgiving.

Full list of additions:
- Creeper mob, with according drops and behaviour
- MOB_GRIEFING global (defined by default)
- placeCraterStructure function, which fills a sphere of given radius with air
- "blew up" death message
