### PR TITLE
Add tool durability bar

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include "registries.h"
+
 #ifdef ESP_PLATFORM
   #define WIFI_SSID "your-ssid"
   #define WIFI_PASS "your-password"
@@ -104,6 +106,31 @@
 
 // Size of the receive buffer for incoming string data
 #define MAX_RECV_BUF_LEN 256
+
+// Tools that should have a durability decrease when breaking a block
+#define TOOLS { \
+    I_wooden_pickaxe, I_wooden_axe, I_wooden_shovel, \
+    I_stone_pickaxe,  I_stone_axe,  I_stone_shovel, \
+    I_iron_pickaxe,   I_iron_axe,   I_iron_shovel, \
+    I_golden_pickaxe, I_golden_axe, I_golden_shovel, \
+    I_diamond_pickaxe,I_diamond_axe,I_diamond_shovel, \
+    I_netherite_pickaxe, I_netherite_axe, I_netherite_shovel, \
+    I_shears \
+}
+
+// The durability of each tool
+#define TOOL_DURABILITY { \
+    59, 59, 59, \
+    131, 131, 131, \
+    250, 250, 250, \
+    32, 32, 32, \
+    1561, 1561, 1561, \
+    2031, 2031, 2031, \
+    238 \
+}
+
+// You must to ensure this after changing the options ahead!!!
+#define TOOL_COUNT 19
 
 // If defined, sends the server brand to clients. Doesn't do much, but will
 // show up in the top-left of the F3/debug menu, in the Minecraft client.
@@ -272,5 +299,8 @@ extern PlayerData player_data[MAX_PLAYERS];
 extern int player_data_count;
 
 extern MobData mob_data[MAX_MOBS];
+
+extern uint16_t tools[];
+extern uint16_t tool_durability[];
 
 #endif

--- a/include/packets.h
+++ b/include/packets.h
@@ -39,6 +39,7 @@ int sc_updateTime (int client_fd, uint64_t ticks);
 int sc_setCenterChunk (int client_fd, int x, int y);
 int sc_chunkDataAndUpdateLight (int client_fd, int _x, int _z);
 int sc_keepAlive (int client_fd);
+int sc_setContainerSlotWithComponent (int client_fd, int window_id, uint16_t slot, uint8_t count, uint16_t item, uint8_t component_to_add_amount, uint8_t component_type, uint16_t component_content);
 int sc_setContainerSlot (int client_fd, int window_id, uint16_t slot, uint8_t count, uint16_t item);
 int sc_setCursorItem (int client_fd, uint16_t item, uint8_t count);
 int sc_setHeldItem (int client_fd, uint8_t slot);

--- a/include/tools.h
+++ b/include/tools.h
@@ -37,12 +37,12 @@ double readDouble (int client_fd);
 ssize_t readLengthPrefixedData (int client_fd);
 void readString (int client_fd);
 void readStringN (int client_fd, uint32_t max_length);
-bool readSlotData(int client_fd, uint16_t *item, uint8_t *count);
+uint8_t readSlotData(int client_fd, uint16_t *item, uint8_t *count);
 
 uint32_t fast_rand ();
 uint64_t splitmix64 (uint64_t state);
 
-bool is_tool(uint16_t item);
+uint8_t is_tool(uint16_t item);
 uint16_t get_tool_durability(int item);
 
 #ifdef ESP_PLATFORM

--- a/include/tools.h
+++ b/include/tools.h
@@ -28,6 +28,7 @@ uint8_t readByte (int client_fd);
 uint16_t readUint16 (int client_fd);
 int16_t readInt16 (int client_fd);
 uint32_t readUint32 (int client_fd);
+int32_t readInt32 (int client_fd);
 uint64_t readUint64 (int client_fd);
 int64_t readInt64 (int client_fd);
 float readFloat (int client_fd);
@@ -36,9 +37,13 @@ double readDouble (int client_fd);
 ssize_t readLengthPrefixedData (int client_fd);
 void readString (int client_fd);
 void readStringN (int client_fd, uint32_t max_length);
+bool readSlotData(int client_fd, uint16_t *item, uint8_t *count);
 
 uint32_t fast_rand ();
 uint64_t splitmix64 (uint64_t state);
+
+bool is_tool(uint16_t item);
+uint16_t get_tool_durability(int item);
 
 #ifdef ESP_PLATFORM
   #include "esp_timer.h"

--- a/src/globals.c
+++ b/src/globals.c
@@ -54,3 +54,6 @@ PlayerData player_data[MAX_PLAYERS];
 int player_data_count = 0;
 
 MobData mob_data[MAX_MOBS];
+
+uint16_t tools[] = TOOLS;
+uint16_t tool_durability[] = TOOL_DURABILITY;

--- a/src/packets.c
+++ b/src/packets.c
@@ -477,7 +477,8 @@ int sc_setContainerSlot(int client_fd, int window_id, uint16_t slot, uint8_t cou
   
   if (is_tool(item)){  
     if (count > 1) {
-      return sc_setContainerSlotWithComponent(client_fd, window_id, slot, 1, item, 1, 3, max(((uint32_t)(count - 1) * get_tool_durability(item)) / 256, 1));
+      uint16_t calc_val = ((uint32_t)(count - 1) * get_tool_durability(item)) / 256;
+      return sc_setContainerSlotWithComponent(client_fd, window_id, slot, 1, item, 1, 3, (calc_val > 1) ? calc_val : 1);
     }
     else {
       return sc_setContainerSlotWithComponent(client_fd, window_id, slot, 1, item, 0, 0, 0);

--- a/src/packets.c
+++ b/src/packets.c
@@ -641,7 +641,7 @@ int cs_clickContainer (int client_fd) {
 
   // Temp vars to prevent durability changes when moving tool in container slots
   uint8_t amount = 0;
-  uint16_t *q_item;
+  uint16_t *q_item = NULL;
   uint8_t *q_count;
 
   #ifdef ALLOW_CHESTS
@@ -676,7 +676,7 @@ int cs_clickContainer (int client_fd) {
         if (is_tool(*p_item)) {
           player->flagval_8 = *p_count;
           player->flagval_16 = *p_item;
-          if (is_tool(*q_item)) {
+          if (q_item && is_tool(*q_item)) {
             *q_count = *p_count;
             #ifdef ALLOW_CHESTS
             if (window_id == 2 && amount > 40) {

--- a/src/tools.c
+++ b/src/tools.c
@@ -276,7 +276,7 @@ void readStringN (int client_fd, uint32_t max_length) {
 }
 
 // Reads a Slot Data and return if there is any item
-bool readSlotData(int client_fd, uint16_t *item, uint8_t *count) {
+uint8_t readSlotData(int client_fd, uint16_t *item, uint8_t *count) {
   if (readByte(client_fd)) {
     *item = readVarInt(client_fd);
     *count = (uint8_t)readVarInt(client_fd);
@@ -312,7 +312,7 @@ uint64_t splitmix64 (uint64_t state) {
   return z ^ (z >> 31);
 }
 
-bool is_tool(uint16_t item) {
+uint8_t is_tool(uint16_t item) {
     for (uint8_t i = 0; i < TOOL_COUNT; i++) {
         if (tools[i] == item) return 1;
     }


### PR DESCRIPTION
I added the durability bar to tools to replace the original randomly-broken logic.
Earlier discussion is in [issues/172](https://github.com/p2r3/bareiron/issues/172)

When I was playing Minecraft, I have a principle that only let one of my pickaxes has it's durability bar. in other words, keep the extra tools completely new. But if the tools even don't have the durability bar and just broken randomly, it really makes me uneasy. Sometimes, I even think I was playing Terraria! That's why I made this pull request.

In this pull request, I used the amount of tool (inventory_count field) to store the durability message. In Minecraft, the tools can only have one in each slot, which means the inventory_count field of a tool is always set to a meaningless number 1. I just made the number 1 means the full durability when the number 255 means the tool should broken. It causes no extra memory usage but preformed well.

Accordingly, I also made the following changes:
 - defined a list of tools which should have a durability and how many durabilities they should have.
 - updated the "S->C Set Container Slot" packet to make it able to send the durability message.
 - updated the "C->S Click Container" packet to prevent durability changes when moving tools in container slots

Since the inventory_count field only ranging from 0 to 255, it is not enough to store the exact durability. Considered that what I have added is just a durability bar rather than the number of the durability, I made the durability decreased randomly. While not pixel-perfect, it's statistically accurate. As long as you isn't boring enough to count how many blocks a pickaxe can break, It is completely same as the vanilla Minecraft.

This is my first github pull request. If my pull request is incorrect or has any issues, I’m happy to make corrections.
Thank you for creating and maintaining such an inspiring project. I’d be grateful if you could take a moment to review. 

<img width="1282" height="782" alt="image" src="https://github.com/user-attachments/assets/f03fb05b-c7e7-4b47-9f3c-a4b467b437c1" />
<img width="1282" height="782" alt="image" src="https://github.com/user-attachments/assets/656a360c-0c5c-41d7-9791-2b5bbed09a15" />
<img width="1282" height="782" alt="image" src="https://github.com/user-attachments/assets/2b9847e8-8208-4ee8-be86-155cff717cb5" />