### PR TITLE
Fix -Werror=implicit-fallthrough build failure in crafting.c

### DIFF
--- a/src/crafting.c
+++ b/src/crafting.c
@@ -111,6 +111,7 @@ void getCraftingOutput (PlayerData *player, uint8_t *count, uint16_t *item) {
             *count = 6;
             return;
           }
+          __attribute__((fallthrough));
         case I_iron_ingot:
         case I_gold_ingot:
         case I_diamond:
@@ -247,6 +248,7 @@ void getCraftingOutput (PlayerData *player, uint8_t *count, uint16_t *item) {
             first_item == I_oak_planks ||
             first_item == I_cobblestone
           ) break;
+          __attribute__((fallthrough));
         case I_leather:
           // Helmet recipes
           if (


### PR DESCRIPTION
## Summary
- Fixes #194 — ESP-IDF/PlatformIO builds fail with `-Werror=implicit-fallthrough` on two spots in `getCraftingOutput()` in `src/crafting.c`.
- Both fallthroughs are intentional (slab-recipe case group falls into the shovel/sword case group, and the axe-recipe break-guard falls into the helmet case group, so shared items like `oak_planks`/`cobblestone` get checked against both recipe sets). The fix annotates them with `__attribute__((fallthrough));` instead of adding a `break;`, since a bare `break` (as suggested in the issue thread) would silently remove the shovel/sword/helmet recipes for wood, stone, and leather items.
- `__attribute__((fallthrough))` is a GCC/Clang extension independent of the C standard version, so it works under this project's C89-compatibility goal (per the discussion in #81 about not using C23's `[[fallthrough]]`).

## Test plan
- [x] Reproduced the exact reported errors (`error: unannotated fall-through between switch labels` at both call sites) by compiling the pre-fix `crafting.c` with `-Wimplicit-fallthrough -Werror`.
- [x] Confirmed the patched file compiles cleanly with the same flags against the project's real headers (stubbed only the registries.h enum, which is normally generated from a vanilla server jar).
- [x] Diff is 2 lines, no behavior change on the taken branches — only silences the fallthrough diagnostic on the paths that already fell through.